### PR TITLE
Router getParam 메서드 return값  객체로 변경

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -99,13 +99,13 @@ export default class Router {
     if (paramKeys.length) {
       const currentPaths = location.pathname.split('/');
 
-      const currentParams = [];
+      const currentParam = {};
 
       paramKeys.forEach((paramKeys) => {
-        currentParams.push({ [paramKeys.key]: currentPaths[paramKeys.index] });
+        currentParam[paramKeys.key] = currentPaths[paramKeys.index];
       });
 
-      return currentParams;
+      return currentParam;
     }
 
     return null;


### PR DESCRIPTION
### 변경 점 요약
- router.js의 getParam의 리턴값 배열에서 객체로 변경
기존 예시: [{articleId: '123'}, {commentId: '123'}]
변경 예시: {articleId: '123', commentId: '123'}
